### PR TITLE
Use a buffered channel for responses.

### DIFF
--- a/request.go
+++ b/request.go
@@ -56,7 +56,7 @@ type RequestOptions struct {
 }
 
 func doRequest(requestVerb, url string, ro *RequestOptions) chan *Response {
-	responseChan := make(chan *Response)
+	responseChan := make(chan *Response, 1)
 	go func() {
 		responseChan <- buildResponse(buildRequest(requestVerb, url, ro))
 	}()


### PR DESCRIPTION
This prevents a leak of goroutines if the return channel is never read.