### PR TITLE
feature(custom-timeouts): user can configure Transport / Dial timeouts

### DIFF
--- a/base_get_test.go
+++ b/base_get_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"testing"
+	"time"
 )
 
 type BasicGetResponse struct {
@@ -94,6 +95,20 @@ type TestJSONCookies struct {
 
 func TestGetNoOptions(t *testing.T) {
 	verifyOkResponse(<-GetAsync("http://httpbin.org/get", nil), t)
+}
+
+func TestGetCustomTLSHandshakeTimeout(t *testing.T) {
+	ro := &RequestOptions{TLSHandshakeTimeout: 10 * time.Millisecond}
+	if _, err := Get("https://httpbin.org", ro); err == nil {
+		t.Error("unexpected: successful TLS Handshake")
+	}
+}
+
+func TestGetCustomDialTimeout(t *testing.T) {
+	ro := &RequestOptions{DialTimeout: time.Millisecond}
+	if _, err := Get("http://httpbin.org:8888", ro); err == nil {
+		t.Error("unexpected: successful connection")
+	}
 }
 
 func TestGetProxy(t *testing.T) {

--- a/request.go
+++ b/request.go
@@ -108,15 +108,10 @@ func buildRequest(httpMethod, url string, ro *RequestOptions) (*http.Response, e
 	httpClient := buildHTTPClient(ro)
 
 	// Build our URL
-	var err error
+	url, err := buildURLParams(url, ro.Params)
 
-	if ro.Params != nil {
-		url, err = buildURLParams(url, ro.Params)
-
-		if err != nil {
-			return nil, err
-		}
-
+	if err != nil {
+		return nil, err
 	}
 
 	// Build the request
@@ -128,7 +123,6 @@ func buildRequest(httpMethod, url string, ro *RequestOptions) (*http.Response, e
 
 	// Do we need to add any HTTP headers or Basic Auth?
 	addHTTPHeaders(ro, req)
-
 	addCookies(ro, req)
 
 	return httpClient.Do(req)
@@ -344,7 +338,7 @@ func buildHTTPClient(ro *RequestOptions) *http.Client {
 			TLSHandshakeTimeout: ro.TLSHandshakeTimeout,
 
 			// Here comes the user settings
-			TLSClientConfig:    &tls.Config{InsecureSkipVerify: ro.InsecureSkipVerify == true},
+			TLSClientConfig:    &tls.Config{InsecureSkipVerify: ro.InsecureSkipVerify},
 			DisableCompression: ro.DisableCompression,
 		},
 	}


### PR DESCRIPTION
Since we can configure the timeouts, I think we don't need the `http.DefaultClient` anymore.
I'd like to know what you think about that @levigross.

BTW, now all tests are passing :)