### PR TITLE
Update createBasicXMLRequest

### DIFF
--- a/base_post_test.go
+++ b/base_post_test.go
@@ -351,6 +351,75 @@ func TestXMLPostRequest(t *testing.T) {
 
 }
 
+func TestXMLMarshaledStringPostRequest(t *testing.T) {
+	xmlStruct := XMLPostMessage{Name: "Human", Age: 1, Height: 1}
+	encoded, _ := xml.Marshal(xmlStruct)
+	resp, _ := Post("http://httpbin.org/post",
+		&RequestOptions{XML: string(encoded)})
+
+	if resp.Error != nil {
+		t.Fatal("Unable to make request", resp.Error)
+	}
+
+	if resp.Ok != true {
+		t.Error("Request did not return OK")
+	}
+
+	myJSONStruct := &BasicPostJSONResponse{}
+	if err := resp.JSON(myJSONStruct); err != nil {
+		t.Error("Unable to response to JSON", err)
+	}
+
+	if myJSONStruct.Data != string(encoded) {
+		t.Error("Response is not valid", myJSONStruct.Data, string(encoded))
+	}
+}
+
+func TestXMLMarshaledBytesPostRequest(t *testing.T) {
+	xmlStruct := XMLPostMessage{Name: "Human", Age: 1, Height: 1}
+	encoded, _ := xml.Marshal(xmlStruct)
+	resp, _ := Post("http://httpbin.org/post",
+		&RequestOptions{XML: encoded})
+
+	if resp.Error != nil {
+		t.Fatal("Unable to make request", resp.Error)
+	}
+
+	if resp.Ok != true {
+		t.Error("Request did not return OK")
+	}
+
+	myJSONStruct := &BasicPostJSONResponse{}
+	if err := resp.JSON(myJSONStruct); err != nil {
+		t.Error("Unable to response to JSON", err)
+	}
+
+	if myJSONStruct.Data != string(encoded) {
+		t.Error("Response is not valid", myJSONStruct.Data, string(encoded))
+	}
+}
+
+func TestXMLNilPostRequest(t *testing.T) {
+	resp, _ := Post("http://httpbin.org/post", &RequestOptions{XML: nil})
+
+	if resp.Error != nil {
+		t.Fatal("Unable to make request", resp.Error)
+	}
+
+	if resp.Ok != true {
+		t.Error("Request did not return OK")
+	}
+
+	myJSONStruct := &BasicPostJSONResponse{}
+	if err := resp.JSON(myJSONStruct); err != nil {
+		t.Error("Unable to response to JSON", err)
+	}
+
+	if myJSONStruct.Data != "" {
+		t.Error("Response is not valid", myJSONStruct.Data)
+	}
+}
+
 func TestBasicPostRequestUploadErrorReader(t *testing.T) {
 	var rd dataAndErrorBuffer
 	rd.err = fmt.Errorf("Random Error")

--- a/request.go
+++ b/request.go
@@ -189,10 +189,15 @@ func createFileUploadRequest(httpMethod, userURL string, ro *RequestOptions) (*h
 func createBasicXMLRequest(httpMethod, userURL string, ro *RequestOptions) (*http.Request, error) {
 	tempBuffer := &bytes.Buffer{}
 
-	if str, ok := ro.XML.(string); ok {
-		tempBuffer.WriteString(str)
-	} else if err := xml.NewEncoder(tempBuffer).Encode(ro.XML); err != nil {
-		return nil, err
+	switch ro.XML.(type) {
+	case string:
+		tempBuffer.WriteString(ro.XML.(string))
+	case []byte:
+		tempBuffer.Write(ro.XML.([]byte))
+	default:
+		if err := xml.NewEncoder(tempBuffer).Encode(ro.XML); err != nil {
+			return nil, err
+		}
 	}
 
 	req, err := http.NewRequest(httpMethod, userURL, tempBuffer)

--- a/request.go
+++ b/request.go
@@ -189,7 +189,9 @@ func createFileUploadRequest(httpMethod, userURL string, ro *RequestOptions) (*h
 func createBasicXMLRequest(httpMethod, userURL string, ro *RequestOptions) (*http.Request, error) {
 	tempBuffer := &bytes.Buffer{}
 
-	if err := xml.NewEncoder(tempBuffer).Encode(ro.XML); err != nil {
+	if str, ok := ro.XML.(string); ok {
+		tempBuffer.WriteString(str)
+	} else if err := xml.NewEncoder(tempBuffer).Encode(ro.XML); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
If provided serialized XML, use it as is. So if I create XML in code I can use it without encoding in grequests.