### PR TITLE
fix json body extra newline

### DIFF
--- a/request.go
+++ b/request.go
@@ -286,19 +286,21 @@ func createMultiPartPostRequest(httpMethod, userURL string, ro *RequestOptions) 
 
 func createBasicJSONRequest(httpMethod, userURL string, ro *RequestOptions) (*http.Request, error) {
 
-	tempBuffer := &bytes.Buffer{}
+	var reader io.Reader
 	switch ro.JSON.(type) {
 	case string:
-		tempBuffer.WriteString(ro.JSON.(string))
+		reader = strings.NewReader(ro.JSON.(string))
 	case []byte:
-		tempBuffer.Write(ro.JSON.([]byte))
+		reader = bytes.NewReader(ro.JSON.([]byte))
 	default:
-		if err := json.NewEncoder(tempBuffer).Encode(ro.JSON); err != nil {
+		byteSlice, err := json.Marshal(ro.JSON)
+		if err != nil {
 			return nil, err
 		}
+		reader = bytes.NewReader(byteSlice)
 	}
 
-	req, err := http.NewRequest(httpMethod, userURL, tempBuffer)
+	req, err := http.NewRequest(httpMethod, userURL, reader)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
POST json body now use json.Encoder#Encode()

This will result a trailing newline. It's mostly for json stream. Not useful in HTTP and will cause some problem.

Should use json.Marshal() instead.