### PR TITLE
add global options

### DIFF
--- a/request.go
+++ b/request.go
@@ -62,6 +62,9 @@ type RequestOptions struct {
 	// UserAgent allows you to set an arbitrary custom user agent
 	UserAgent string
 
+	// Host allows you to set an arbitrary custom host
+	Host string
+
 	// Auth allows you to specify a user name and password that you wish to
 	// use when requesting the URL. It will use basic HTTP authentication
 	// formatting the username and password in base64 the format is:
@@ -506,6 +509,10 @@ func addHTTPHeaders(ro *RequestOptions, req *http.Request) {
 		req.Header.Set("User-Agent", ro.UserAgent)
 	} else {
 		req.Header.Set("User-Agent", localUserAgent)
+	}
+
+	if ro.Host != "" {
+		req.Host = ro.Host
 	}
 
 	if ro.Auth != nil {

--- a/session.go
+++ b/session.go
@@ -5,6 +5,8 @@ import "net/http"
 // Session allows a user to make use of persistent cookies in between
 // HTTP requests
 type Session struct {
+	// RequestOptions is global options
+	RequestOptions *RequestOptions
 
 	// HTTPClient is the client that we will use to request the resources
 	HTTPClient *http.Client
@@ -20,7 +22,42 @@ func NewSession(ro *RequestOptions) *Session {
 
 	ro.UseCookieJar = true
 
-	return &Session{HTTPClient: BuildHTTPClient(*ro)}
+	return &Session{RequestOptions: ro, HTTPClient: BuildHTTPClient(*ro)}
+}
+
+// Combine session options and request options
+// 1. UserAgent
+// 2. Host
+// 3. Auth
+// 4. Headers
+func (s *Session) combineRequestOptions(ro *RequestOptions) *RequestOptions {
+	if ro == nil {
+		ro = &RequestOptions{}
+	}
+
+	if ro.UserAgent == "" && s.RequestOptions.UserAgent != "" {
+		ro.UserAgent = s.RequestOptions.UserAgent
+	}
+
+	if ro.Host == "" && s.RequestOptions.Host != "" {
+		ro.Host = s.RequestOptions.Host
+	}
+
+	if ro.Auth == nil && s.RequestOptions.Auth != nil {
+		ro.Auth = s.RequestOptions.Auth
+	}
+
+	if len(s.RequestOptions.Headers) > 0 || len(ro.Headers) > 0 {
+		headers := make(map[string]string)
+		for k, v := range s.RequestOptions.Headers {
+			headers[k] = v
+		}
+		for k, v := range ro.Headers {
+			headers[k] = v
+		}
+		ro.Headers = headers
+	}
+	return ro
 }
 
 // Get takes 2 parameters and returns a Response Struct. These two options are:
@@ -29,6 +66,7 @@ func NewSession(ro *RequestOptions) *Session {
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
 func (s *Session) Get(url string, ro *RequestOptions) (*Response, error) {
+	ro = s.combineRequestOptions(ro)
 	return doSessionRequest("GET", url, ro, s.HTTPClient)
 }
 
@@ -38,6 +76,7 @@ func (s *Session) Get(url string, ro *RequestOptions) (*Response, error) {
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
 func (s *Session) Put(url string, ro *RequestOptions) (*Response, error) {
+	ro = s.combineRequestOptions(ro)
 	return doSessionRequest("PUT", url, ro, s.HTTPClient)
 }
 
@@ -47,6 +86,7 @@ func (s *Session) Put(url string, ro *RequestOptions) (*Response, error) {
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
 func (s *Session) Patch(url string, ro *RequestOptions) (*Response, error) {
+	ro = s.combineRequestOptions(ro)
 	return doSessionRequest("PATCH", url, ro, s.HTTPClient)
 }
 
@@ -56,6 +96,7 @@ func (s *Session) Patch(url string, ro *RequestOptions) (*Response, error) {
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
 func (s *Session) Delete(url string, ro *RequestOptions) (*Response, error) {
+	ro = s.combineRequestOptions(ro)
 	return doSessionRequest("DELETE", url, ro, s.HTTPClient)
 }
 
@@ -65,6 +106,7 @@ func (s *Session) Delete(url string, ro *RequestOptions) (*Response, error) {
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
 func (s *Session) Post(url string, ro *RequestOptions) (*Response, error) {
+	ro = s.combineRequestOptions(ro)
 	return doSessionRequest("POST", url, ro, s.HTTPClient)
 }
 
@@ -74,6 +116,7 @@ func (s *Session) Post(url string, ro *RequestOptions) (*Response, error) {
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
 func (s *Session) Head(url string, ro *RequestOptions) (*Response, error) {
+	ro = s.combineRequestOptions(ro)
 	return doSessionRequest("HEAD", url, ro, s.HTTPClient)
 }
 
@@ -83,6 +126,7 @@ func (s *Session) Head(url string, ro *RequestOptions) (*Response, error) {
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
 func (s *Session) Options(url string, ro *RequestOptions) (*Response, error) {
+	ro = s.combineRequestOptions(ro)
 	return doSessionRequest("OPTIONS", url, ro, s.HTTPClient)
 }
 


### PR DESCRIPTION
```go
package main

import (
	"log"
	"net/http/httputil"

	"github.com/levigross/grequests"
)

func main() {
	sess := grequests.NewSession(&grequests.RequestOptions{
		Headers: map[string]string{
			"Accept":          "*/*",
		},
		UserAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.59 Safari/537.36",
	})
	sess = grequests.NewSession(nil)

	resp, err := sess.Get("http://baidu.com", nil)
	if err != nil {
		log.Fatal(err)
	}
	body, err := httputil.DumpRequest(resp.RawResponse.Request, true)
	if err != nil {
		log.Fatal(err)
	}
	println(string(body))
}
```