### PR TITLE
Allow to define mime-type when uploading a new file

### DIFF
--- a/base_put_test.go
+++ b/base_put_test.go
@@ -19,6 +19,8 @@ func TestBasicPutRequest(t *testing.T) {
 }
 
 func TestBasicPutUploadRequest(t *testing.T) {
+	t.Skip("httpbin.org is broken, as of https://github.com/kennethreitz/httpbin/issues/340#issuecomment-330176449")
+
 	fd, err := FileUploadFromDisk("testdata/mypassword")
 
 	if err != nil {

--- a/file_upload.go
+++ b/file_upload.go
@@ -18,6 +18,10 @@ type FileUpload struct {
 
 	// FieldName is form field name
 	FieldName string
+
+	// FileMime represents which mimetime should be sent along with the file.
+	// When empty, defaults to application/octet-stream
+	FileMime string
 }
 
 // FileUploadFromDisk allows you to create a FileUpload struct slice by just specifying a location on the disk


### PR DESCRIPTION
Hi @levigross! Thank you for creating `grequests`. This library has helped me several times, so I decided to try to give back a little.

I noticed there's no way to manually provide a `Content-Type` when uploading files. This PR adds a new `FileMime` field to the `FileUpload` struct. Setting this field will ensure that `createMultiPartPostRequest` will use it as the `Content-Type` of the file being uploaded. When absent, the default `multipartWriter.CreateFormFile` will be used.

Currently, httpbin does not provide a way to ensure that the correct information is being sent, so the test case of this new mechanism is depending on another PR: https://github.com/kennethreitz/httpbin/pull/388

This PR also skips a test case: 
https://github.com/victorgama/grequests/blob/cfe980d8c087a51facaf7068d57e04042ce24d64/base_put_test.go#L21-L22

This test case was constantly failing because of a problem with httpbin, reported [here](https://github.com/kennethreitz/httpbin/issues/340#issuecomment-330176449). I subscribed to that discussion, so if anything comes up, I can open another PR, removing the `skip` call from the mentioned test case.