### PR TITLE
Prevent redirects if RedirectLimit is negative

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -56,6 +56,11 @@ func addRedirectFunctionality(client *http.Client, ro *RequestOptions) {
 		return
 	}
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+
+		if ro.RedirectLimit < 0 {
+			return http.ErrUseLastResponse
+		}
+
 		if ro.RedirectLimit == 0 {
 			ro.RedirectLimit = RedirectLimit
 		}


### PR DESCRIPTION
The only other way to prevent redirect is to supply your own `http.Client` but they you return it immediately without adding any of the settings from `RequestOptions`. And as you already create your own `CheckRedirect` function, this is an easy addition.