### PR TITLE
Extend options for httpClient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/google/go-querystring v1.0.0
 	golang.org/x/net v0.0.0-20181011144130-49bb7cea24b1
 )
+
+go 1.13

--- a/request.go
+++ b/request.go
@@ -120,6 +120,13 @@ type RequestOptions struct {
 	// globally by modifying the `RedirectLimit` variable.
 	RedirectLimit int
 
+	// DisableKeepAlives, if true, disables HTTP keep-alives and
+	// will only use the connection to the server for a single
+	// HTTP request.
+	//
+	// This is unrelated to the similarly named TCP keep-alives.
+	DisableKeepAlives bool
+
 	// MaxIdleConns controls the maximum number of idle (keep-alive)
 	// connections across all hosts. Zero means no limit.
 	MaxIdleConns int
@@ -464,6 +471,7 @@ func (ro RequestOptions) dontUseDefaultClient() bool {
 	case ro.MaxIdleConns != 0:
 	case ro.MaxIdleConnsPerHost != 0:
 	case ro.MaxConnsPerHost != 0:
+	case ro.DisableKeepAlives == true:
 	default:
 		return false
 	}
@@ -533,6 +541,7 @@ func createHTTPTransport(ro RequestOptions) *http.Transport {
 		MaxIdleConns:        ro.MaxIdleConns,
 		MaxIdleConnsPerHost: ro.MaxIdleConnsPerHost,
 		MaxConnsPerHost:     ro.MaxConnsPerHost,
+		DisableKeepAlives:   ro.DisableKeepAlives,
 		// Here comes the user settings
 		TLSClientConfig:    &tls.Config{InsecureSkipVerify: ro.InsecureSkipVerify},
 		DisableCompression: ro.DisableCompression,

--- a/request.go
+++ b/request.go
@@ -120,6 +120,22 @@ type RequestOptions struct {
 	// globally by modifying the `RedirectLimit` variable.
 	RedirectLimit int
 
+	// MaxIdleConns controls the maximum number of idle (keep-alive)
+	// connections across all hosts. Zero means no limit.
+	MaxIdleConns int
+
+	// MaxIdleConnsPerHost, if non-zero, controls the maximum idle
+	// (keep-alive) connections to keep per-host. If zero,
+	// DefaultMaxIdleConnsPerHost is used.
+	MaxIdleConnsPerHost int
+
+	// MaxConnsPerHost optionally limits the total number of
+	// connections per host, including connections in the dialing,
+	// active, and idle states. On limit violation, dials will block.
+	//
+	// Zero means no limit.
+	MaxConnsPerHost int
+
 	// RequestBody allows you to put anything matching an `io.Reader` into the request
 	// this option will take precedence over any other request option specified
 	RequestBody io.Reader
@@ -445,6 +461,9 @@ func (ro RequestOptions) dontUseDefaultClient() bool {
 	case ro.UseCookieJar != false:
 	case ro.RequestTimeout != 0:
 	case ro.LocalAddr != nil:
+	case ro.MaxIdleConns != 0:
+	case ro.MaxIdleConnsPerHost != 0:
+	case ro.MaxConnsPerHost != 0:
 	default:
 		return false
 	}
@@ -511,7 +530,9 @@ func createHTTPTransport(ro RequestOptions) *http.Transport {
 			LocalAddr: ro.LocalAddr,
 		}).Dial,
 		TLSHandshakeTimeout: ro.TLSHandshakeTimeout,
-
+		MaxIdleConns:        ro.MaxIdleConns,
+		MaxIdleConnsPerHost: ro.MaxIdleConnsPerHost,
+		MaxConnsPerHost:     ro.MaxConnsPerHost,
 		// Here comes the user settings
 		TLSClientConfig:    &tls.Config{InsecureSkipVerify: ro.InsecureSkipVerify},
 		DisableCompression: ro.DisableCompression,


### PR DESCRIPTION
There is currently no way to specify these options other than supplying an instance of httpClient in `RequestOptions` as `ro.HTTPClient`. But if we do that, we have to keep track of the other options.

So I added the params specifying TCP connection. I was thinking of a more generic solution, but apart from these, I never needed the rest of options that are missing.