### PR TITLE
Add context-aware requests and update docs

### DIFF
--- a/base.go
+++ b/base.go
@@ -1,70 +1,82 @@
 // Package grequests implements a friendly API over Go's existing net/http library
 package grequests
 
+import "context"
+
 // Get takes 2 parameters and returns a Response Struct. These two options are:
-// 	1. A URL
-// 	2. A set of options for the request
-func Get(url string, options ...Option) (*Response, error) {
-	return Request("GET", url, options...)
+//  1. A URL
+//  2. A set of options for the request
+func Get(ctx context.Context, url string, options ...Option) (*Response, error) {
+	return Request(ctx, "GET", url, options...)
 }
 
 // Put takes 2 parameters and returns a Response struct. These two options are:
-// 	1. A URL
-// 	2. A set of options for the request
+//  1. A URL
+//  2. A set of options for the request
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
-func Put(url string, options ...Option) (*Response, error) {
-	return Request("PUT", url, options...)
+func Put(ctx context.Context, url string, options ...Option) (*Response, error) {
+	return Request(ctx, "PUT", url, options...)
 }
 
 // Patch takes 2 parameters and returns a Response struct. These two options are:
-// 	1. A URL
-// 	2. A set of options for the request
+//  1. A URL
+//  2. A set of options for the request
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
-func Patch(url string, options ...Option) (*Response, error) {
-	return Request("PATCH", url, options...)
+func Patch(ctx context.Context, url string, options ...Option) (*Response, error) {
+	return Request(ctx, "PATCH", url, options...)
 }
 
 // Delete takes 2 parameters and returns a Response struct. These two options are:
-// 	1. A URL
-// 	2. A set of options for the request
+//  1. A URL
+//  2. A set of options for the request
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
-func Delete(url string, options ...Option) (*Response, error) {
-	return Request("DELETE", url, options...)
+func Delete(ctx context.Context, url string, options ...Option) (*Response, error) {
+	return Request(ctx, "DELETE", url, options...)
 }
 
 // Post takes 2 parameters and returns a Response channel. These two options are:
-// 	1. A URL
-// 	2. A set of options for the request
+//  1. A URL
+//  2. A set of options for the request
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
-func Post(url string, options ...Option) (*Response, error) {
-	return Request("POST", url, options...)
+func Post(ctx context.Context, url string, options ...Option) (*Response, error) {
+	return Request(ctx, "POST", url, options...)
 }
 
 // Head takes 2 parameters and returns a Response channel. These two options are:
-// 	1. A URL
-// 	2. A set of options for the request
+//  1. A URL
+//  2. A set of options for the request
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
-func Head(url string, options ...Option) (*Response, error) {
-	return Request("HEAD", url, options...)
+func Head(ctx context.Context, url string, options ...Option) (*Response, error) {
+	return Request(ctx, "HEAD", url, options...)
 }
 
 // Options takes 2 parameters and returns a Response struct. These two options are:
-// 	1. A URL
-// 	2. A set of options for the request
+//  1. A URL
+//  2. A set of options for the request
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
-func Options(url string, options ...Option) (*Response, error) {
-	return Request("OPTIONS", url, options...)
+func Options(ctx context.Context, url string, options ...Option) (*Response, error) {
+	return Request(ctx, "OPTIONS", url, options...)
 }
 
 // Request takes 3 parameters and returns a Response Struct. These three options are:
-//	1. A verb
-// 	2. A URL
-// 	3. A set of options for the request
+//  1. A verb
+//  2. A URL
+//  3. A set of options for the request
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
-func Request(verb string, url string, options ...Option) (*Response, error) {
+func Request(ctx context.Context, verb, url string, options ...Option) (*Response, error) {
 	ro := &RequestOptions{}
 	for _, opt := range options {
 		opt.Apply(ro)
+	}
+	if ctx != nil {
+		ro.Context = ctx
 	}
 	return DoRegularRequest(verb, url, ro)
 }

--- a/base_delete_test.go
+++ b/base_delete_test.go
@@ -1,6 +1,7 @@
 package grequests
 
 import (
+	"context"
 	"net/url"
 	"testing"
 
@@ -15,7 +16,7 @@ func (s *DeleteSuite) TestDeleteRequest() {
 	srv := newDeleteServer()
 	defer srv.Close()
 
-	resp, err := Delete(srv.URL)
+	resp, err := Delete(context.Background(), srv.URL)
 	s.Require().NoError(err)
 	s.True(resp.Ok)
 }
@@ -25,14 +26,14 @@ func (s *DeleteSuite) TestDeleteSessionCookies() {
 	defer srv.Close()
 
 	session := NewSession(nil)
-	_, err := session.Get(srv.URL+"?one=two", nil)
+	_, err := session.Get(context.Background(), srv.URL+"?one=two", nil)
 	s.Require().NoError(err)
-	_, err = session.Get(srv.URL+"?two=three", nil)
+	_, err = session.Get(context.Background(), srv.URL+"?two=three", nil)
 	s.Require().NoError(err)
-	_, err = session.Get(srv.URL+"?three=four", nil)
+	_, err = session.Get(context.Background(), srv.URL+"?three=four", nil)
 	s.Require().NoError(err)
 
-	_, err = session.Delete(srv.URL, nil)
+	_, err = session.Delete(context.Background(), srv.URL, nil)
 	s.Require().NoError(err)
 
 	cookieURL, err := url.Parse(srv.URL)
@@ -42,7 +43,7 @@ func (s *DeleteSuite) TestDeleteSessionCookies() {
 
 func (s *DeleteSuite) TestDeleteInvalidURLSession() {
 	session := NewSession(nil)
-	_, err := session.Delete("%../dir/", nil)
+	_, err := session.Delete(context.Background(), "%../dir/", nil)
 	s.Error(err)
 }
 

--- a/base_get_test.go
+++ b/base_get_test.go
@@ -1,6 +1,7 @@
 package grequests
 
 import (
+	"context"
 	"net/url"
 	"testing"
 
@@ -15,13 +16,13 @@ func (s *GetSuite) TestGetRequest() {
 	srv := newGetServer()
 	defer srv.Close()
 
-	resp, err := Get(srv.URL)
+	resp, err := Get(context.Background(), srv.URL)
 	s.Require().NoError(err)
 	s.True(resp.Ok)
 }
 
 func (s *GetSuite) TestGetInvalidURL() {
-	_, err := Get("%../dir/")
+	_, err := Get(context.Background(), "%../dir/")
 	s.Error(err)
 }
 
@@ -30,9 +31,9 @@ func (s *GetSuite) TestGetSessionCookies() {
 	defer srv.Close()
 
 	session := NewSession(nil)
-	_, err := session.Get(srv.URL+"?one=two", nil)
+	_, err := session.Get(context.Background(), srv.URL+"?one=two", nil)
 	s.Require().NoError(err)
-	_, err = session.Get(srv.URL+"?two=three", nil)
+	_, err = session.Get(context.Background(), srv.URL+"?two=three", nil)
 	s.Require().NoError(err)
 
 	cookieURL, err := url.Parse(srv.URL)

--- a/base_head_test.go
+++ b/base_head_test.go
@@ -1,6 +1,7 @@
 package grequests
 
 import (
+	"context"
 	"net/url"
 	"testing"
 
@@ -15,7 +16,7 @@ func (s *HeadSuite) TestHeadRequest() {
 	srv := newHeadServer()
 	defer srv.Close()
 
-	resp, err := Head(srv.URL)
+	resp, err := Head(context.Background(), srv.URL)
 	s.Require().NoError(err)
 	s.True(resp.Ok)
 	s.Equal("text/plain", resp.Header.Get("Content-Type"))
@@ -26,11 +27,11 @@ func (s *HeadSuite) TestHeadSessionCookies() {
 	defer srv.Close()
 
 	session := NewSession(nil)
-	_, err := session.Head(srv.URL+"?one=two", &RequestOptions{})
+	_, err := session.Head(context.Background(), srv.URL+"?one=two", &RequestOptions{})
 	s.Require().NoError(err)
-	_, err = session.Head(srv.URL+"?two=three", &RequestOptions{})
+	_, err = session.Head(context.Background(), srv.URL+"?two=three", &RequestOptions{})
 	s.Require().NoError(err)
-	_, err = session.Head(srv.URL+"?three=four", &RequestOptions{})
+	_, err = session.Head(context.Background(), srv.URL+"?three=four", &RequestOptions{})
 	s.Require().NoError(err)
 
 	cookieURL, err := url.Parse(srv.URL)
@@ -40,7 +41,7 @@ func (s *HeadSuite) TestHeadSessionCookies() {
 
 func (s *HeadSuite) TestHeadInvalidURLSession() {
 	session := NewSession(nil)
-	_, err := session.Head("%../dir/", nil)
+	_, err := session.Head(context.Background(), "%../dir/", nil)
 	s.Error(err)
 }
 

--- a/base_options_test.go
+++ b/base_options_test.go
@@ -1,6 +1,7 @@
 package grequests
 
 import (
+	"context"
 	"net/url"
 	"testing"
 
@@ -15,7 +16,7 @@ func (s *OptionsSuite) TestOPTIONSRequest() {
 	srv := newOptionsServer()
 	defer srv.Close()
 
-	resp, err := Options(srv.URL)
+	resp, err := Options(context.Background(), srv.URL)
 	s.Require().NoError(err)
 	s.True(resp.Ok)
 	s.Equal("GET, POST, PUT, DELETE, PATCH, OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
@@ -26,11 +27,11 @@ func (s *OptionsSuite) TestOptionsSessionCookies() {
 	defer srv.Close()
 
 	session := NewSession(nil)
-	_, err := session.Options(srv.URL+"?one=two", &RequestOptions{})
+	_, err := session.Options(context.Background(), srv.URL+"?one=two", &RequestOptions{})
 	s.Require().NoError(err)
-	_, err = session.Options(srv.URL+"?two=three", &RequestOptions{})
+	_, err = session.Options(context.Background(), srv.URL+"?two=three", &RequestOptions{})
 	s.Require().NoError(err)
-	_, err = session.Options(srv.URL+"?three=four", &RequestOptions{})
+	_, err = session.Options(context.Background(), srv.URL+"?three=four", &RequestOptions{})
 	s.Require().NoError(err)
 
 	cookieURL, err := url.Parse(srv.URL)
@@ -40,7 +41,7 @@ func (s *OptionsSuite) TestOptionsSessionCookies() {
 
 func (s *OptionsSuite) TestOptionsInvalidURLSession() {
 	session := NewSession(nil)
-	_, err := session.Options("%../dir/", nil)
+	_, err := session.Options(context.Background(), "%../dir/", nil)
 	s.Error(err)
 }
 

--- a/base_patch_test.go
+++ b/base_patch_test.go
@@ -1,6 +1,7 @@
 package grequests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -14,14 +15,14 @@ func (s *PatchSuite) TestPatchRequest() {
 	srv := newPatchServer()
 	defer srv.Close()
 
-	resp, err := Patch(srv.URL, FromRequestOptions(&RequestOptions{Data: map[string]string{"one": "two"}}))
+	resp, err := Patch(context.Background(), srv.URL, FromRequestOptions(&RequestOptions{Data: map[string]string{"one": "two"}}))
 	s.Require().NoError(err)
 	s.True(resp.Ok)
 }
 
 func (s *PatchSuite) TestPatchInvalidURLSession() {
 	session := NewSession(nil)
-	_, err := session.Patch("%../dir/", nil)
+	_, err := session.Patch(context.Background(), "%../dir/", nil)
 	s.Error(err)
 }
 

--- a/base_post_test.go
+++ b/base_post_test.go
@@ -1,6 +1,7 @@
 package grequests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -14,7 +15,7 @@ func (s *PostSuite) TestPostRequest() {
 	srv := newPostServer()
 	defer srv.Close()
 
-	resp, err := Post(srv.URL, FromRequestOptions(&RequestOptions{Data: map[string]string{"one": "two"}}))
+	resp, err := Post(context.Background(), srv.URL, FromRequestOptions(&RequestOptions{Data: map[string]string{"one": "two"}}))
 	s.Require().NoError(err)
 	s.True(resp.Ok)
 }
@@ -24,13 +25,13 @@ func (s *PostSuite) TestPostSession() {
 	defer srv.Close()
 
 	session := NewSession(nil)
-	resp, err := session.Post(srv.URL, &RequestOptions{Data: map[string]string{"one": "two"}})
+	resp, err := session.Post(context.Background(), srv.URL, &RequestOptions{Data: map[string]string{"one": "two"}})
 	s.Require().NoError(err)
 	s.True(resp.Ok)
 }
 
 func (s *PostSuite) TestPostInvalidURL() {
-	_, err := Post("%../dir/")
+	_, err := Post(context.Background(), "%../dir/")
 	s.Error(err)
 }
 

--- a/base_put_test.go
+++ b/base_put_test.go
@@ -1,6 +1,7 @@
 package grequests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -14,14 +15,14 @@ func (s *PutSuite) TestPutRequest() {
 	srv := newPutServer()
 	defer srv.Close()
 
-	resp, err := Put(srv.URL, FromRequestOptions(&RequestOptions{Data: map[string]string{"one": "two"}}))
+	resp, err := Put(context.Background(), srv.URL, FromRequestOptions(&RequestOptions{Data: map[string]string{"one": "two"}}))
 	s.Require().NoError(err)
 	s.True(resp.Ok)
 }
 
 func (s *PutSuite) TestPutInvalidURLSession() {
 	session := NewSession(nil)
-	_, err := session.Put("%../dir/", nil)
+	_, err := session.Put(context.Background(), "%../dir/", nil)
 	s.Error(err)
 }
 

--- a/extra_test.go
+++ b/extra_test.go
@@ -76,7 +76,7 @@ type ResponseMethodSuite struct{ suite.Suite }
 func (s *ResponseMethodSuite) TestJSONAndBytes() {
 	srv := newJSONServer(map[string]string{"foo": "bar"})
 	defer srv.Close()
-	resp, err := Get(srv.URL)
+	resp, err := Get(context.Background(), srv.URL)
 	s.Require().NoError(err)
 	s.NotEmpty(resp.String())
 	b := resp.Bytes()
@@ -92,7 +92,7 @@ func (s *ResponseMethodSuite) TestXMLAndDownload() {
 	xmlData := "<root><foo>bar</foo></root>"
 	srv := newXMLServer(xmlData)
 	defer srv.Close()
-	resp, err := Get(srv.URL)
+	resp, err := Get(context.Background(), srv.URL)
 	s.Require().NoError(err)
 	var v struct {
 		Foo string `xml:"foo"`
@@ -100,7 +100,7 @@ func (s *ResponseMethodSuite) TestXMLAndDownload() {
 	s.NoError(resp.XML(&v, nil))
 	s.Equal("bar", v.Foo)
 
-	resp2, err := Get(srv.URL)
+	resp2, err := Get(context.Background(), srv.URL)
 	s.Require().NoError(err)
 	file := "test_download.tmp"
 	s.NoError(resp2.DownloadToFile(file))

--- a/request.go
+++ b/request.go
@@ -335,7 +335,9 @@ func createMultiPartPostRequest(httpMethod, userURL string, ro *RequestOptions) 
 
 	// Populate the other parts of the form (if there are any)
 	for key, value := range ro.Data {
-		multipartWriter.WriteField(key, value)
+		if err := multipartWriter.WriteField(key, value); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := multipartWriter.Close(); err != nil {
@@ -435,14 +437,14 @@ func (ro RequestOptions) proxySettings(req *http.Request) (*url.URL, error) {
 // 9. Do you want to set a custom LocalAddr to send the request from
 func (ro RequestOptions) dontUseDefaultClient() bool {
 	switch {
-	case ro.InsecureSkipVerify == true:
-	case ro.DisableCompression == true:
+	case ro.InsecureSkipVerify:
+	case ro.DisableCompression:
 	case len(ro.Proxies) != 0:
 	case ro.TLSHandshakeTimeout != 0:
 	case ro.DialTimeout != 0:
 	case ro.DialKeepAlive != 0:
 	case len(ro.Cookies) != 0:
-	case ro.UseCookieJar != false:
+	case ro.UseCookieJar:
 	case ro.RequestTimeout != 0:
 	case ro.LocalAddr != nil:
 	default:
@@ -566,7 +568,7 @@ func addHTTPHeaders(ro *RequestOptions, req *http.Request) {
 		req.SetBasicAuth(ro.Auth[0], ro.Auth[1])
 	}
 
-	if ro.IsAjax == true {
+	if ro.IsAjax {
 		req.Header.Set("X-Requested-With", "XMLHttpRequest")
 	}
 }
@@ -578,7 +580,7 @@ func addCookies(ro *RequestOptions, req *http.Request) {
 }
 
 func addQueryParams(parsedURL *url.URL, parsedQuery url.Values) string {
-	return strings.Join([]string{strings.Replace(parsedURL.String(), "?"+parsedURL.RawQuery, "", -1), parsedQuery.Encode()}, "?")
+	return strings.Join([]string{strings.ReplaceAll(parsedURL.String(), "?"+parsedURL.RawQuery, ""), parsedQuery.Encode()}, "?")
 }
 
 func buildURLStruct(userURL string, URLStruct interface{}) (string, error) {

--- a/response.go
+++ b/response.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 )
@@ -68,8 +67,9 @@ func (r *Response) Close() error {
 		return r.Error
 	}
 
-	io.Copy(ioutil.Discard, r)
-
+	if _, err := io.Copy(io.Discard, r); err != nil && err != io.EOF {
+		return err
+	}
 	return r.RawResponse.Body.Close()
 }
 
@@ -86,8 +86,8 @@ func (r *Response) DownloadToFile(fileName string) error {
 		return err
 	}
 
-	defer r.Close() // This is a noop if we use the internal ByteBuffer
-	defer fd.Close()
+	defer func() { _ = r.Close() }() // This is a noop if we use the internal ByteBuffer
+	defer func() { _ = fd.Close() }()
 
 	if _, err := io.Copy(fd, r.getInternalReader()); err != nil && err != io.EOF {
 		return err
@@ -120,7 +120,7 @@ func (r *Response) XML(userStruct interface{}, charsetReader XMLCharDecoder) err
 		xmlDecoder.CharsetReader = charsetReader
 	}
 
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	return xmlDecoder.Decode(&userStruct)
 }
@@ -134,7 +134,7 @@ func (r *Response) JSON(userStruct interface{}) error {
 	}
 
 	jsonDecoder := json.NewDecoder(r.getInternalReader())
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	return jsonDecoder.Decode(&userStruct)
 }
@@ -148,7 +148,7 @@ func (r *Response) populateResponseByteBuffer() {
 		return
 	}
 
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	// Is there any content?
 	if r.RawResponse.ContentLength == 0 {
@@ -162,7 +162,7 @@ func (r *Response) populateResponseByteBuffer() {
 
 	if _, err := io.Copy(r.internalByteBuffer, r); err != nil && err != io.EOF {
 		r.Error = err
-		r.RawResponse.Body.Close()
+		_ = r.RawResponse.Body.Close()
 	}
 
 }

--- a/response_test.go
+++ b/response_test.go
@@ -1,6 +1,7 @@
 package grequests
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -14,7 +15,7 @@ func (s *ResponseSuite) TestResponseOk() {
 	statuses := []int{200, 201, 202, 203, 204, 205, 206, 207, 208, 226}
 	for _, status := range statuses {
 		srv := newStatusServer(status)
-		resp, err := Get(srv.URL)
+		resp, err := Get(context.Background(), srv.URL)
 		srv.Close()
 		s.Require().NoError(err)
 		s.Equal(status, resp.StatusCode)

--- a/session.go
+++ b/session.go
@@ -1,6 +1,9 @@
 package grequests
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // Session allows a user to make use of persistent cookies in between
 // HTTP requests
@@ -61,72 +64,100 @@ func (s *Session) combineRequestOptions(ro *RequestOptions) *RequestOptions {
 }
 
 // Get takes 2 parameters and returns a Response Struct. These two options are:
-// 	1. A URL
-// 	2. A RequestOptions struct
+//  1. A URL
+//  2. A RequestOptions struct
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
-func (s *Session) Get(url string, ro *RequestOptions) (*Response, error) {
+func (s *Session) Get(ctx context.Context, url string, ro *RequestOptions) (*Response, error) {
 	ro = s.combineRequestOptions(ro)
+	if ctx != nil {
+		ro.Context = ctx
+	}
 	return doSessionRequest("GET", url, ro, s.HTTPClient)
 }
 
 // Put takes 2 parameters and returns a Response struct. These two options are:
-// 	1. A URL
-// 	2. A RequestOptions struct
+//  1. A URL
+//  2. A RequestOptions struct
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
-func (s *Session) Put(url string, ro *RequestOptions) (*Response, error) {
+func (s *Session) Put(ctx context.Context, url string, ro *RequestOptions) (*Response, error) {
 	ro = s.combineRequestOptions(ro)
+	if ctx != nil {
+		ro.Context = ctx
+	}
 	return doSessionRequest("PUT", url, ro, s.HTTPClient)
 }
 
 // Patch takes 2 parameters and returns a Response struct. These two options are:
-// 	1. A URL
-// 	2. A RequestOptions struct
+//  1. A URL
+//  2. A RequestOptions struct
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
-func (s *Session) Patch(url string, ro *RequestOptions) (*Response, error) {
+func (s *Session) Patch(ctx context.Context, url string, ro *RequestOptions) (*Response, error) {
 	ro = s.combineRequestOptions(ro)
+	if ctx != nil {
+		ro.Context = ctx
+	}
 	return doSessionRequest("PATCH", url, ro, s.HTTPClient)
 }
 
 // Delete takes 2 parameters and returns a Response struct. These two options are:
-// 	1. A URL
-// 	2. A RequestOptions struct
+//  1. A URL
+//  2. A RequestOptions struct
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
-func (s *Session) Delete(url string, ro *RequestOptions) (*Response, error) {
+func (s *Session) Delete(ctx context.Context, url string, ro *RequestOptions) (*Response, error) {
 	ro = s.combineRequestOptions(ro)
+	if ctx != nil {
+		ro.Context = ctx
+	}
 	return doSessionRequest("DELETE", url, ro, s.HTTPClient)
 }
 
 // Post takes 2 parameters and returns a Response channel. These two options are:
-// 	1. A URL
-// 	2. A RequestOptions struct
+//  1. A URL
+//  2. A RequestOptions struct
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
-func (s *Session) Post(url string, ro *RequestOptions) (*Response, error) {
+func (s *Session) Post(ctx context.Context, url string, ro *RequestOptions) (*Response, error) {
 	ro = s.combineRequestOptions(ro)
+	if ctx != nil {
+		ro.Context = ctx
+	}
 	return doSessionRequest("POST", url, ro, s.HTTPClient)
 }
 
 // Head takes 2 parameters and returns a Response channel. These two options are:
-// 	1. A URL
-// 	2. A RequestOptions struct
+//  1. A URL
+//  2. A RequestOptions struct
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
-func (s *Session) Head(url string, ro *RequestOptions) (*Response, error) {
+func (s *Session) Head(ctx context.Context, url string, ro *RequestOptions) (*Response, error) {
 	ro = s.combineRequestOptions(ro)
+	if ctx != nil {
+		ro.Context = ctx
+	}
 	return doSessionRequest("HEAD", url, ro, s.HTTPClient)
 }
 
 // Options takes 2 parameters and returns a Response struct. These two options are:
-// 	1. A URL
-// 	2. A RequestOptions struct
+//  1. A URL
+//  2. A RequestOptions struct
+//
 // If you do not intend to use the `RequestOptions` you can just pass nil
 // A new session is created by calling NewSession with a request options struct
-func (s *Session) Options(url string, ro *RequestOptions) (*Response, error) {
+func (s *Session) Options(ctx context.Context, url string, ro *RequestOptions) (*Response, error) {
 	ro = s.combineRequestOptions(ro)
+	if ctx != nil {
+		ro.Context = ctx
+	}
 	return doSessionRequest("OPTIONS", url, ro, s.HTTPClient)
 }
 


### PR DESCRIPTION
## Summary
- document usage and features in a refreshed README
- make high level request functions accept `context.Context`
- update session methods to accept contexts
- handle several linter warnings
- update tests for the new APIs

## Testing
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`
- `golint ./...`
